### PR TITLE
Fix overflow off-by-one error

### DIFF
--- a/ht-time.py
+++ b/ht-time.py
@@ -7,7 +7,6 @@ import struct
 import datetime
 import csv
 import argparse
-import math
 
 parser = argparse.ArgumentParser(
     prog = 'Hydro Thunder Time Tool',
@@ -284,7 +283,7 @@ def checksum_calc(drive):
         if checksum % 2 == 0:
             parity = not(parity)
         
-        checksum = (checksum % 0xFFFFFFFe) + (parity)  + args.lsb_offset# Use mask to set parity bit
+        checksum = checksum + parity + args.lsb_offset# Use mask to set parity bit
 
         f.seek(drive.blocks[args.block]+ht.data.checksum_offset)
         f.write(checksum.to_bytes(4,"little", signed=False))

--- a/ht-time.py
+++ b/ht-time.py
@@ -274,14 +274,12 @@ def checksum_calc(drive):
             next_int_bytes = f.read(4)
             next_int = int.from_bytes(next_int_bytes, "little", signed=False)
             checksum = (checksum+next_int)
+            # Simulate overflows for uint32 type
+            if checksum > 0xFFFFFFFF:
+                checksum = (checksum % 0xFFFFFFFF) - 1
             #parity = parity+(next_int % 0x1)# Use mask to force overflow
             if next_int % 2 == 0:
                 parity = not(parity)
-        
-        # Simulate overflows for uint32 type
-        num_overflows = math.floor(checksum / 0xFFFFFFFF)
-        checksum = checksum - (num_overflows)
-        checksum = checksum % 0xFFFFFFFF
         
         if checksum % 2 == 0:
             parity = not(parity)

--- a/ht-time.py
+++ b/ht-time.py
@@ -7,6 +7,7 @@ import struct
 import datetime
 import csv
 import argparse
+import math
 
 parser = argparse.ArgumentParser(
     prog = 'Hydro Thunder Time Tool',
@@ -99,7 +100,7 @@ class ht:
         size = 8192 # Rough size rounded up to nice number
         header = bytearray(b'\x01\x00\x00\x00\x98\xba\xdc\xfe') # Always present
         checksum_offset = 12 # Bytes from data start to checksum
-        checksum_seed=0xFEDCBA94
+        checksum_seed=0xFEDCBAF2
         section_bytes={"header":12,"checksum":4,"static1":4,"config":360,"times":1040,"static2":4,"splits":260,"audit":6508}
         config_offset=20
         times_offset=380
@@ -272,13 +273,19 @@ def checksum_calc(drive):
         for count in range(int_read):
             next_int_bytes = f.read(4)
             next_int = int.from_bytes(next_int_bytes, "little", signed=False)
-            checksum = (checksum+next_int) % 0xFFFFFFFF # Use mask to force overflow
+            checksum = (checksum+next_int)
             #parity = parity+(next_int % 0x1)# Use mask to force overflow
             if next_int % 2 == 0:
                 parity = not(parity)
-
+        
+        # Simulate overflows for uint32 type
+        num_overflows = math.floor(checksum / 0xFFFFFFFF)
+        checksum = checksum - (num_overflows)
+        checksum = checksum % 0xFFFFFFFF
+        
         if checksum % 2 == 0:
             parity = not(parity)
+        
         checksum = (checksum % 0xFFFFFFFe) + (parity)  + args.lsb_offset# Use mask to set parity bit
 
         f.seek(drive.blocks[args.block]+ht.data.checksum_offset)


### PR DESCRIPTION
Apologies I had to drop this project for a couple weeks to focus on a research conference and journal, but I heard you were considering a follow up video and probably needed this checksum script to work for that, so I hammered out that last little issue with it today with a refreshed viewpoint and the very useful PCem emulation.

Turns out the overflow simulation with `checksum % 0xFFFFFFFF` is off by 1 bit, this error was just subtracted out in the seed which explains why previously the checksum worked, but only for small edits, any large edits that caused an under/overflow would be off by ±2 bits and even larger changes with multiple overflows would be off by even more. Was just sheer luck all the example images had overflowed the same number of times so this escaped early detection until large edits were made to the high score table.

This pull adds code to *correctly* simulate this uint32 overflow behaviour on top of the Python int numeric. I verified this makes correct checksums for high score tables filled with `AAA` and `ZZZ` (attached below) along with a couple random ones in between.

* [oops!-all-As.zip](https://github.com/AkBKukU/HydroThunder-TimeTool/files/10831207/oops.-all-As.zip)
* [oops!-all-Zs.zip](https://github.com/AkBKukU/HydroThunder-TimeTool/files/10831210/oops.-all-Zs.zip)
* [checksum-0xFFFFFFFF.zip](https://github.com/AkBKukU/HydroThunder-TimeTool/files/10834621/checksum-0xFFFFFFFF.zip)

Hopefully this was the last issue between you and a high score table with real WR times. 

### TODO
* [x] Fix off-by-one overflow error
* [x] Fix `uint64` 16 GiB limitation
* [x] Fix `0xFFFFFFFF` edge case
